### PR TITLE
Patched dependency issue of WebUI #23

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,22 +15,22 @@ repos:
       - id: no-commit-to-branch
         args: ["--branch", "main", "--branch", "develop"]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.2
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.0
+    rev: v2.1.1
     hooks:
       - id: autoflake
         args: [

--- a/colliderscope/webui.py
+++ b/colliderscope/webui.py
@@ -88,8 +88,8 @@ def gcl_to_json(graph: gcl.Graphicle) -> str:
     df["final"] = graph.final.data
     df["pdg"] = graph.pdg.data
     df["status"] = graph.status.data
-    df["in"] = graph.edges["in"]
-    df["out"] = graph.edges["out"]
+    df["src"] = graph.edges["src"]
+    df["dst"] = graph.edges["dst"]
     df["color"] = graph.color.data["color"]
     df["anticolor"] = graph.color.data["anticolor"]
     for coord in "xyze":
@@ -102,7 +102,7 @@ def gcl_to_json(graph: gcl.Graphicle) -> str:
 
 
 def maskgroup_to_json(masks: gcl.MaskGroup[gcl.MaskArray]) -> str:
-    json_str = pd.DataFrame(masks.dict).to_json(
+    json_str = pd.DataFrame(masks.serialize()).to_json(
         date_format="iso", orient="split"
     )
     if json_str is None:
@@ -119,7 +119,7 @@ def json_to_gcl(json_str: str) -> gcl.Graphicle:
         status=df["status"].values,  # type: ignore
         pmu=df[list("xyze")].values,  # type: ignore
         color=df[["color", "anticolor"]].values,  # type: ignore
-        edges=df[["in", "out"]].values,  # type: ignore
+        edges=df[["src", "dst"]].values,  # type: ignore
     )
     lg.info("Reading JSON string into Graphicle object.")
     return graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyvis <=0.1.9",
     "colour",
     "webcolors",
-    "graphicle >=0.2.6",
+    "graphicle >=0.3.0",
     "plotly",
     "more-itertools >=2.1",
 ]


### PR DESCRIPTION
WebUI depended on graphicle<0.3. This has been patched, so now colliderscope depends on graphicle>=0.3.