### PR TITLE
Patched dependency issue #23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyvis <=0.1.9",
     "colour",
     "webcolors",
-    "graphicle >=0.3.0",
+    "graphicle >=0.3.2",
     "plotly",
     "more-itertools >=2.1",
 ]


### PR DESCRIPTION
WebUI relied on graphicle<0.3. Now patched and updated the dependency so colliderscope needs graphicle>=0.3.2.