### PR TITLE
Patch: eta_phi_network parameters #34

### DIFF
--- a/colliderscope/__init__.py
+++ b/colliderscope/__init__.py
@@ -1039,7 +1039,7 @@ def eta_phi_network(
         Plotly figure of particles on the :math:`\\eta-\\phi` plane,
         with edges connecting adjacent particles, defined by ``radius``.
     """
-    if bool(radius) ^ bool(adj_matrix):
+    if (radius is None) and (adj_matrix is None):
         raise ValueError("Either radius or adjacency must be passed.")
     pmu = _iterable_to_momentum(pmu)
     NUM_PCLS = len(pmu)

--- a/colliderscope/__init__.py
+++ b/colliderscope/__init__.py
@@ -1058,8 +1058,8 @@ def eta_phi_network(
         )
         if colorbar_title is not None:
             marker_opts["colorbar"]["title"] = colorbar_title
-        if marker_symbols is not None:
-            marker_opts["symbol"] = marker_symbols
+    if marker_symbols is not None:
+        marker_opts["symbol"] = marker_symbols
     if radius:
         adj_matrix = pmu.delta_R(pmu) < radius
     eta = pmu.eta


### PR DESCRIPTION
# eta_phi_network fixes:

- Correct parameter guard for `radius` and `adj_matrix`, allowing only one to be passed
- May pass `marker_symbols` without needing to pass `color`