### PR TITLE
Added config param for ReadTheDocs+Sphinx #36

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,7 @@ build:
 
 sphinx:
   fail_on_warning: false
+  configuration: docs/source/conf.py
 
 python:
   install:


### PR DESCRIPTION
ReadTheDocs now requires a parameter showing the path of the config file for Sphinx. Added.